### PR TITLE
Update Prerequisites

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/Assert-PrereqsAreInstalledAndLoaded.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/Assert-PrereqsAreInstalledAndLoaded.ps1
@@ -74,7 +74,7 @@ foreach ($module in $modules) {
         }
     }
     else {
-        $availableModule = Get-InstalledModule -Name $module.Name -ErrorAction SilentlyContinue | Where-Object { [version]$_.Version -eq [version]$module.RequiredVersion }
+        $availableModule = Get-InstalledModule -Name $module.Name -AllVersions -ErrorAction SilentlyContinue | Where-Object { [version]$_.Version -eq [version]$module.RequiredVersion }
         if(-Not ($availableModule)) {
             Read-InstallMissingPrerequisite -Module $module
         }


### PR DESCRIPTION
Uptaking latest AZ modules and setting them to required version instead of minimum version to avoid issues with newer versions that may break things.