### PR TITLE
Add validation for vnet Ids on Enterprise Policy creation

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/VnetValidations.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/VnetValidations.ps1
@@ -119,6 +119,11 @@ function Get-VirtualNetwork{
         [string] $EnterprisePolicyLocation
     )
 
+    if ($VirtualNetworkId.EndsWith("/"))
+    {
+        throw "The VirtualNetworkId parameter has a trailing slash. Please remove the trailing slash and try again. Provided value: $VirtualNetworkId"
+    }
+
     $vnetResource = Get-AzResource -ResourceId $VirtualNetworkId
     if ($null -eq $vnetResource.ResourceId)
     {

--- a/Source/Tests/VnetValidations.Tests.ps1
+++ b/Source/Tests/VnetValidations.Tests.ps1
@@ -69,6 +69,10 @@ Describe 'VnetValidations Tests' {
                 $result.ResourceId | Should -Be $mockVnet.ResourceId
             }
 
+            It 'Throws when VirtualNetworkId has trailing slash' {
+                { Get-VirtualNetwork -VirtualNetworkId "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/" -EnterprisePolicyLocation "unitedstates" } | Should -Throw "*trailing slash*"
+            }
+
             It 'Throws when VNet is not found' {
                 Mock Get-AzResource { return [PSCustomObject]@{ ResourceId = $null } }
 


### PR DESCRIPTION
This pull request adds validation to ensure that the `VirtualNetworkId` parameter in the `Get-VirtualNetwork` function does not have a trailing slash, and introduces a corresponding test to verify this behavior.

Validation improvements:

* Added a check in `Get-VirtualNetwork` (in `VnetValidations.ps1`) to throw an error if the provided `VirtualNetworkId` ends with a trailing slash, including a descriptive error message.

Testing enhancements:

* Added a test case in `VnetValidations.Tests.ps1` to ensure that an exception is thrown when `Get-VirtualNetwork` is called with a `VirtualNetworkId` that has a trailing slash.The Get-VirtualNetwork function now checks for trailing slashes in the VirtualNetworkId parameter and throws a clear error message asking users to remove it. This prevents cryptic Azure API errors when users accidentally include trailing slashes in VNet resource IDs.

Changes:
- Added trailing slash validation in Get-VirtualNetwork function
- Added test case to verify the validation works correctly

Fixes issue where VNet IDs with trailing slashes would fail with unclear error messages.