### PR TITLE
Fix region cache returning stale data in PowerShell Core +semver:patch

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/CacheMethods.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/CacheMethods.ps1
@@ -57,6 +57,12 @@ function Initialize-Cache{
         else{
             $script:CacheData = $content | ConvertFrom-Json
             $script:CacheData = Update-CacheVersion -Cache $script:CacheData
+            foreach($key in $script:CacheData.RegionCache.PSObject.Properties.Name){
+                $entry = $script:CacheData.RegionCache.$key
+                if($entry.Expiry -is [string]){
+                    $entry.Expiry = [DateTime]::Parse($entry.Expiry).ToUniversalTime()
+                }
+            }
         }
     }
 }
@@ -108,15 +114,16 @@ function Get-EnvironmentRegionFromCache{
 
     # Check for cached entry
     if($script:CacheData.RegionCache.PSObject.Properties.Name -contains $cacheKey){
+        $now = [DateTime]::UtcNow
         $entry = $script:CacheData.RegionCache.$cacheKey
         $expiry = if($entry.Expiry -is [DateTime]){
                 $entry.Expiry.ToUniversalTime()
             }
             else{
-                [DateTime]::Parse($entry.Expiry).ToUniversalTime()
+                $entry.Expiry = $now
             }
-        if($expiry -gt [DateTime]::UtcNow){
-            $remainingMinutes = [math]::Round(($expiry - [DateTime]::UtcNow).TotalMinutes, 1)
+        if($expiry -gt $now){
+            $remainingMinutes = [math]::Round(($expiry - $now).TotalMinutes, 1)
             Write-Verbose "Region cache hit for $cacheKey. Region: $($entry.Region). Cache valid for $remainingMinutes more minutes."
             return $entry.Region
         }
@@ -138,7 +145,7 @@ function Get-EnvironmentRegionFromCache{
     # Store in cache with 1-hour expiry
     $cacheEntry = [PSCustomObject]@{
         Region = $region
-        Expiry = [DateTime]::UtcNow.AddHours(1).ToString("o")
+        Expiry = [DateTime]::UtcNow.AddHours(1)
     }
     if($script:CacheData.RegionCache.PSObject.Properties.Name -contains $cacheKey){
         $script:CacheData.RegionCache.$cacheKey = $cacheEntry

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/CacheMethods.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/CacheMethods.ps1
@@ -109,9 +109,15 @@ function Get-EnvironmentRegionFromCache{
     # Check for cached entry
     if($script:CacheData.RegionCache.PSObject.Properties.Name -contains $cacheKey){
         $entry = $script:CacheData.RegionCache.$cacheKey
-        $expiry = [DateTime]::Parse($entry.Expiry).ToUniversalTime()
+        $expiry = if($entry.Expiry -is [DateTime]){
+                $entry.Expiry.ToUniversalTime()
+            }
+            else{
+                [DateTime]::Parse($entry.Expiry).ToUniversalTime()
+            }
         if($expiry -gt [DateTime]::UtcNow){
-            Write-Verbose "Region cache hit for $cacheKey"
+            $remainingMinutes = [math]::Round(($expiry - [DateTime]::UtcNow).TotalMinutes, 1)
+            Write-Verbose "Region cache hit for $cacheKey. Region: $($entry.Region). Cache valid for $remainingMinutes more minutes."
             return $entry.Region
         }
     }
@@ -127,6 +133,7 @@ function Get-EnvironmentRegionFromCache{
     }
 
     $region = Get-EnvironmentRegion @params
+    Write-Verbose "Region resolved for $cacheKey. Region: $region. Caching for 1 hour."
 
     # Store in cache with 1-hour expiry
     $cacheEntry = [PSCustomObject]@{

--- a/Source/Tests/CacheMethods.Tests.ps1
+++ b/Source/Tests/CacheMethods.Tests.ps1
@@ -221,6 +221,38 @@ Describe 'CacheMethods Tests' {
                 Should -Invoke Get-EnvironmentRegion -Times 1 -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
             }
 
+            It 'Refreshes expired entries after disk roundtrip' {
+                # Populate cache with an expired entry and save to disk
+                $cacheKey = "env-123|prod"
+                $script:CacheData.RegionCache | Add-Member -NotePropertyName $cacheKey -NotePropertyValue ([PSCustomObject]@{
+                    Region = "oldregion"
+                    Expiry = [DateTime]::UtcNow.AddHours(-1).ToString("o")
+                })
+                Save-Cache
+
+                # Reload from disk (ConvertFrom-Json in PS Core converts date strings to DateTime)
+                Initialize-Cache
+
+                $result = Get-EnvironmentRegionFromCache -EnvironmentId "env-123" -Endpoint ([PPEndpoint]::Prod)
+
+                $result | Should -Be "westus"
+                Should -Invoke Get-EnvironmentRegion -Times 1 -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            }
+
+            It 'Returns cached value after disk roundtrip when not expired' {
+                # First call populates the cache
+                Get-EnvironmentRegionFromCache -EnvironmentId "env-123" -Endpoint ([PPEndpoint]::Prod)
+                # Save and reload from disk
+                Save-Cache
+                Initialize-Cache
+
+                # Second call should use cache loaded from disk
+                $result = Get-EnvironmentRegionFromCache -EnvironmentId "env-123" -Endpoint ([PPEndpoint]::Prod)
+
+                $result | Should -Be "westus"
+                Should -Invoke Get-EnvironmentRegion -Times 1 -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            }
+
             It 'Passes TenantId through when provided' {
                 Mock Get-EnvironmentRegion { return "eastus" } -ParameterFilter { $TenantId -eq "tenant-abc" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
 


### PR DESCRIPTION
ConvertFrom-Json in PS Core auto-converts ISO 8601 date strings to DateTime objects with Kind=Utc. When passed to [DateTime]::Parse(), the implicit ToString() stripped timezone info, causing ToUniversalTime() to double-adjust the UTC offset. This made expired cache entries appear valid for hours beyond their actual expiry.

Also improved cache verbose logging to include the cached region and remaining TTL.