### PR TITLE
Add Test-AppInsightsConnectivity diagnostic cmdlet +semver:minor

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Test-AppInsightsConnectivity.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Test-AppInsightsConnectivity.ps1
@@ -96,7 +96,7 @@ function Test-AppInsightsConnectivity{
         }
         elseif ($PSBoundParameters.ContainsKey('Message')) {
             if ($information.TestMessageSent) {
-                Write-Host "Application Insights connectivity succeeded and test event sent from [$($information.ContainerIpAddress)]."
+                Write-Host "Application Insights connectivity succeeded and test event sent from [$($information.ContainerIpAddress)]. Verify that the message arrived in your Application Insights resource - ingestion can take several minutes."
             }
             else {
                 Write-Warning "Application Insights connectivity test from [$($information.ContainerIpAddress)] failed to send the test event: $($information.ErrorMessage)"

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Test-AppInsightsConnectivity.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Test-AppInsightsConnectivity.ps1
@@ -1,0 +1,113 @@
+<#
+SAMPLE CODE NOTICE
+
+THIS SAMPLE CODE IS MADE AVAILABLE AS IS. MICROSOFT MAKES NO WARRANTIES, WHETHER EXPRESS OR IMPLIED,
+OF FITNESS FOR A PARTICULAR PURPOSE, OF ACCURACY OR COMPLETENESS OF RESPONSES, OF RESULTS, OR CONDITIONS OF MERCHANTABILITY.
+THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS SAMPLE CODE REMAINS WITH THE USER.
+NO TECHNICAL SUPPORT IS PROVIDED. YOU MAY NOT DISTRIBUTE THIS CODE UNLESS YOU HAVE A LICENSE AGREEMENT WITH MICROSOFT THAT ALLOWS YOU TO DO SO.
+#>
+
+<#
+.SYNOPSIS
+Tests network connectivity to the Application Insights ingestion endpoint described by a connection string.
+
+.DESCRIPTION
+The Test-AppInsightsConnectivity cmdlet validates that the Application Insights ingestion endpoint described by the supplied connection string is reachable from the delegated subnet of the specified environment. Optionally, a test telemetry event can be sent along with the connectivity check by supplying a message.
+The test is executed in the context of your delegated subnet in the region that you specify.
+If the region isn't specified, it defaults to the region of the environment.
+
+.OUTPUTS
+ApplicationInsightsInformation
+A class representing the result of the Application Insights connectivity test. [ApplicationInsightsInformation](ApplicationInsightsInformation.md)
+
+.EXAMPLE
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/"
+
+Tests connectivity to the Application Insights ingestion endpoint from the environment's delegated subnet.
+
+.EXAMPLE
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=...;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/" -Message "Hello from Power Platform"
+
+Tests connectivity and additionally sends a test telemetry event with the supplied message.
+
+.EXAMPLE
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=...;IngestionEndpoint=https://usgovvirginia-0.in.applicationinsights.azure.us/" -Endpoint usgovhigh
+
+Tests connectivity from an environment in the US Government High cloud.
+
+.EXAMPLE
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "..." -Region "westus"
+
+Tests connectivity from the westus region instead of the environment's default region.
+#>
+function Test-AppInsightsConnectivity{
+    param(
+        [Parameter(Mandatory, HelpMessage="The Id of the environment to test the Application Insights connectivity from.")]
+        [ValidateNotNullOrEmpty()]
+        [string]$EnvironmentId,
+
+        [Parameter(Mandatory, HelpMessage="The Application Insights connection string whose ingestion endpoint should be tested.")]
+        [ValidateNotNullOrEmpty()]
+        [string]$ConnectionString,
+
+        [Parameter(Mandatory=$false, HelpMessage="Optional message body to send as a test telemetry event alongside the connectivity check.")]
+        [string]$Message,
+
+        [Parameter(Mandatory=$false, HelpMessage="The id of the tenant that the environment belongs to.")]
+        [string]$TenantId,
+
+        [Parameter(Mandatory=$false, HelpMessage="The Power Platform endpoint to connect to. Defaults to 'prod'.")]
+        [PPEndpoint]$Endpoint = [PPEndpoint]::Prod,
+
+        [Parameter(Mandatory=$false, HelpMessage="The Azure region in which to test the connectivity. Defaults to the region the environment is in.")]
+        [string]$Region,
+
+        [Parameter(Mandatory=$false, HelpMessage="Force re-authentication to Azure.")]
+        [switch]$ForceAuth
+    )
+
+    $ErrorActionPreference = "Stop"
+
+    if (-not(Connect-Azure -Endpoint $Endpoint -TenantId $TenantId -Force:$ForceAuth)) {
+        throw "Failed to connect to Azure. Please check your credentials and try again."
+    }
+
+    $path = "/plex/testAppInsightsConnection"
+    if ([string]::IsNullOrWhiteSpace($Region)) {
+        $Region = Get-EnvironmentRegionFromCache -EnvironmentId $EnvironmentId -Endpoint $Endpoint -TenantId $TenantId
+    }
+    $query = "api-version=2026-02-01&region=$Region"
+
+    $Body = @{
+        ConnectionString = $ConnectionString
+        Message = if ([string]::IsNullOrWhiteSpace($Message)) { "" } else { $Message }
+    }
+
+    $result = Send-RequestWithRetries -MaxRetries 3 -DelaySeconds 2 -RequestFactory {
+        return New-EnvironmentRouteRequest -EnvironmentId $EnvironmentId -Path $path -Query $query -AccessToken (Get-PPAPIAccessToken -Endpoint $Endpoint -TenantId $TenantId) -HttpMethod ([System.Net.Http.HttpMethod]::Post) -Content ($Body | ConvertTo-Json) -Endpoint $Endpoint
+    }
+
+    $contentString = Get-AsyncResult -Task $result.Content.ReadAsStringAsync()
+
+    try{
+        $information = ConvertFrom-JsonToClass -Json $contentString -ClassType ([ApplicationInsightsInformation])
+        if (-not $information.ConnectionStringValid) {
+            Write-Warning "Application Insights connection string is invalid: $($information.ErrorMessage)"
+        }
+        elseif ($PSBoundParameters.ContainsKey('Message')) {
+            if ($information.TestMessageSent) {
+                Write-Host "Application Insights connectivity succeeded and test event sent from [$($information.ContainerIpAddress)]."
+            }
+            else {
+                Write-Warning "Application Insights connectivity test from [$($information.ContainerIpAddress)] failed to send the test event: $($information.ErrorMessage)"
+            }
+        }
+        else {
+            Write-Host "Application Insights connectivity succeeded from [$($information.ContainerIpAddress)]."
+        }
+        return $information
+    } catch {
+        Write-Verbose "Failed to convert response to JSON: $($_.Exception.Message)"
+        return $contentString
+    }
+}

--- a/Source/Tests/Test-AppInsightsConnectivity.Tests.ps1
+++ b/Source/Tests/Test-AppInsightsConnectivity.Tests.ps1
@@ -1,0 +1,104 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Unit test code")]
+param()
+
+BeforeDiscovery{
+    . $PSScriptRoot\Shared.ps1
+}
+
+Describe 'Test-AppInsightsConnectivity Tests' {
+    BeforeAll {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+        $secureString = (ConvertTo-SecureString "MySecretValue" -AsPlainText -Force)
+        Mock Get-PPAPIAccessToken { return $secureString } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+        Mock Write-Host {} -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+        Mock Write-Warning {} -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+        Mock Connect-Azure { return $true } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+        $script:connectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/"
+        $script:environmentId = "3496a854-39b3-41bd-a783-1f2479ca3fbd"
+        $script:endpoint = [PPEndpoint]::prod
+        $script:region = "westus"
+    }
+
+    Context 'Testing Test-AppInsightsConnectivity' {
+        It 'Returns ApplicationInsightsInformation when connectivity succeeds without a message' {
+            $stringResult = '{"ConnectionStringValid":true,"TestMessageSent":false,"ErrorMessage":null,"ContainerIpAddress":"10.1.2.3"}'
+            $mockResult = [HttpClientResultMock]::new($stringResult, "application/json")
+
+            Mock Send-RequestWithRetries { return $mockResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-AsyncResult { return $stringResult } -ParameterFilter { $task -eq $stringResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $result = Test-AppInsightsConnectivity -EnvironmentId $script:environmentId -ConnectionString $script:connectionString -Endpoint $script:endpoint -Region $script:region
+
+            $result | Should -BeOfType [ApplicationInsightsInformation]
+            $result.ConnectionStringValid | Should -BeTrue
+            Should -Not -Invoke Write-Warning -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+        }
+
+        It 'Sends Message in the request body when supplied' {
+            $stringResult = '{"ConnectionStringValid":true,"TestMessageSent":true,"ErrorMessage":null,"ContainerIpAddress":"10.1.2.3"}'
+            $mockResult = [HttpClientResultMock]::new($stringResult, "application/json")
+            $script:capturedContent = $null
+
+            Mock Send-RequestWithRetries {
+                $null = & $RequestFactory
+                return $mockResult
+            } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock New-EnvironmentRouteRequest {
+                $script:capturedContent = $Content
+                return "request"
+            } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-AsyncResult { return $stringResult } -ParameterFilter { $task -eq $stringResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $null = Test-AppInsightsConnectivity -EnvironmentId $script:environmentId -ConnectionString $script:connectionString -Message "hello" -Endpoint $script:endpoint -Region $script:region
+
+            $script:capturedContent | Should -Match '"Message"\s*:\s*"hello"'
+        }
+
+        It 'Sends an empty Message in the request body when not supplied' {
+            $stringResult = '{"ConnectionStringValid":true,"TestMessageSent":false,"ErrorMessage":null,"ContainerIpAddress":"10.1.2.3"}'
+            $mockResult = [HttpClientResultMock]::new($stringResult, "application/json")
+            $script:capturedContent = $null
+
+            Mock Send-RequestWithRetries {
+                $null = & $RequestFactory
+                return $mockResult
+            } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock New-EnvironmentRouteRequest {
+                $script:capturedContent = $Content
+                return "request"
+            } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-AsyncResult { return $stringResult } -ParameterFilter { $task -eq $stringResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $null = Test-AppInsightsConnectivity -EnvironmentId $script:environmentId -ConnectionString $script:connectionString -Endpoint $script:endpoint -Region $script:region
+
+            $script:capturedContent | Should -Match '"Message"\s*:\s*""'
+        }
+
+        It 'Warns when the connection string is invalid' {
+            $stringResult = '{"ConnectionStringValid":false,"TestMessageSent":false,"ErrorMessage":"Malformed connection string","ContainerIpAddress":"10.1.2.3"}'
+            $mockResult = [HttpClientResultMock]::new($stringResult, "application/json")
+
+            Mock Send-RequestWithRetries { return $mockResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-AsyncResult { return $stringResult } -ParameterFilter { $task -eq $stringResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $result = Test-AppInsightsConnectivity -EnvironmentId $script:environmentId -ConnectionString "garbage" -Endpoint $script:endpoint -Region $script:region
+
+            $result.ConnectionStringValid | Should -BeFalse
+            Should -Invoke Write-Warning -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies" -ParameterFilter { $Message -like "*connection string is invalid*" }
+        }
+
+        It 'Auto-resolves region when not provided' {
+            $stringResult = '{"ConnectionStringValid":true,"TestMessageSent":false,"ErrorMessage":null,"ContainerIpAddress":"10.1.2.3"}'
+            $mockResult = [HttpClientResultMock]::new($stringResult, "application/json")
+
+            Mock Send-RequestWithRetries { return $mockResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-AsyncResult { return $stringResult } -ParameterFilter { $task -eq $stringResult } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-EnvironmentRegionFromCache { return "westus" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $null = Test-AppInsightsConnectivity -EnvironmentId $script:environmentId -ConnectionString $script:connectionString -Endpoint $script:endpoint
+
+            Should -Invoke Get-EnvironmentRegionFromCache -Times 1 -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+        }
+    }
+}

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Microsoft.PowerPlatform.EnterprisePolicies.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Microsoft.PowerPlatform.EnterprisePolicies.md
@@ -5,7 +5,7 @@ HelpInfoUri:
 Locale: en-US
 Module Guid: fce8ece4-09c1-4455-9253-c68b6c2ea4d6
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 05/07/2026
+ms.date: 05/12/2026
 PlatyPS schema version: 2024-05-01
 title: Microsoft.PowerPlatform.EnterprisePolicies Module
 ---
@@ -82,13 +82,17 @@ Validates that the account has the correct permissions to run diagnostic command
 
 Tests connectivity to Application Insights by sending a test telemetry event from a specified environment.
 
+### [Test-AppInsightsConnectivity](Test-AppInsightsConnectivity.md)
+
+Tests network connectivity to the Application Insights ingestion endpoint described by a connection string.
+
 ### [Test-DnsResolution](Test-DnsResolution.md)
 
 Tests the Domain Name System (DNS) resolution for a given hostname in a specified environment.
 
 ### [Test-NetworkConnectivity](Test-NetworkConnectivity.md)
 
-Tests the connectivity to a given service in a specified environment.
+Tests the connectivity to a given service in the specified environment.
 
 ### [Test-TLSHandshake](Test-TLSHandshake.md)
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-AppInsightsConnectivity.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-AppInsightsConnectivity.md
@@ -1,0 +1,236 @@
+---
+document type: cmdlet
+external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: Microsoft.PowerPlatform.EnterprisePolicies
+ms.date: 05/12/2026
+PlatyPS schema version: 2024-05-01
+title: Test-AppInsightsConnectivity
+---
+
+# Test-AppInsightsConnectivity
+
+## SYNOPSIS
+
+Tests network connectivity to the Application Insights ingestion endpoint described by a connection string.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Test-AppInsightsConnectivity [-EnvironmentId] <string> [-ConnectionString] <string>
+ [[-Message] <string>] [[-TenantId] <string>] [[-Endpoint] <PPEndpoint>] [[-Region] <string>]
+ [-ForceAuth] [<CommonParameters>]
+```
+
+## ALIASES
+
+This cmdlet has the following aliases,
+  {{Insert list of aliases}}
+
+## DESCRIPTION
+
+The Test-AppInsightsConnectivity cmdlet validates that the Application Insights ingestion endpoint described by the supplied connection string is reachable from the delegated subnet of the specified environment.
+Optionally, a test telemetry event can be sent along with the connectivity check by supplying a message.
+The test is executed in the context of your delegated subnet in the region that you specify.
+If the region isn't specified, it defaults to the region of the environment.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/"
+
+Tests connectivity to the Application Insights ingestion endpoint from the environment's delegated subnet.
+
+### EXAMPLE 2
+
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=...;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/" -Message "Hello from Power Platform"
+
+Tests connectivity and additionally sends a test telemetry event with the supplied message.
+
+### EXAMPLE 3
+
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "InstrumentationKey=...;IngestionEndpoint=https://usgovvirginia-0.in.applicationinsights.azure.us/" -Endpoint usgovhigh
+
+Tests connectivity from an environment in the US Government High cloud.
+
+### EXAMPLE 4
+
+Test-AppInsightsConnectivity -EnvironmentId "00000000-0000-0000-0000-000000000000" -ConnectionString "..." -Region "westus"
+
+Tests connectivity from the westus region instead of the environment's default region.
+
+## PARAMETERS
+
+### -ConnectionString
+
+The Application Insights connection string whose ingestion endpoint should be tested.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 1
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Endpoint
+
+The Power Platform endpoint to connect to. Defaults to 'prod'.
+
+```yaml
+Type: PPEndpoint
+DefaultValue: prod
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 4
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -EnvironmentId
+
+The Id of the environment to test the Application Insights connectivity from.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ForceAuth
+
+Force re-authentication to Azure.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Message
+
+Optional message body to send as a test telemetry event alongside the connectivity check.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 2
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Region
+
+The Azure region in which to test the connectivity. Defaults to the region the environment is in.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 5
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -TenantId
+
+The id of the tenant that the environment belongs to.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 3
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### ApplicationInsightsInformation
+A class representing the result of the Application Insights connectivity test. [ApplicationInsightsInformation](ApplicationInsightsInformation.md)
+
+{{ Fill in the Description }}
+
+## NOTES
+
+## RELATED LINKS
+
+{{ Fill in the related links here }}
+


### PR DESCRIPTION
Tests reachability of the Application Insights ingestion endpoint described by a connection string, from the delegated subnet of the specified environment. Optional Message parameter sends a test telemetry event alongside the connectivity check. Returns ApplicationInsightsInformation, matching Test-AppInsightsConnection's output type.

Backend path: /plex/testAppInsightsConnection, api-version 2026-02-01. Body always carries ConnectionString and Message as strings (empty Message when omitted).