### PR TITLE
Add UAE location mapping to Enable-SubnetInjection compatibility check

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
@@ -147,7 +147,8 @@ function Enable-SubnetInjection {
 
     if ($environmentLocation -ine $policyLocation) {
         if( ($environmentLocation -eq "unitedstates" -and $policyLocation -eq "unitedstateseuap") -or
-            ($environmentLocation -eq "unitedkingdom" -and $policyLocation -eq "uk") ) {
+            ($environmentLocation -eq "unitedkingdom" -and $policyLocation -eq "uk") -or
+            ($environmentLocation -eq "unitedarabemirates" -and $policyLocation -eq "uae") ) {
             Write-Verbose "Environment is in '$environmentLocation' and policy is in '$policyLocation'. Treating locations as compatible."
         }
         else {

--- a/Source/Tests/Enable-SubnetInjection.Tests.ps1
+++ b/Source/Tests/Enable-SubnetInjection.Tests.ps1
@@ -284,5 +284,36 @@ Describe 'Enable-SubnetInjection Tests' {
 
             $result | Should -Be $true
         }
+
+        It 'Should treat unitedarabemirates environment with uae policy as compatible' {
+            $mockEnvironmentUnitedArabEmirates = [PSCustomObject]@{
+                name = $script:testEnvironmentId
+                location = "unitedarabemirates"
+                properties = @{
+                    enterprisePolicies = $null
+                }
+            }
+            $mockPolicyUae = [PSCustomObject]@{
+                ResourceId = $script:testPolicyArmId
+                Name = $script:testPolicyName
+                Kind = "NetworkInjection"
+                Location = "uae"
+                Properties = @{
+                    systemId = $script:testPolicySystemId
+                }
+            }
+
+            Mock Connect-Azure { return $true } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-PPEnvironment { return $mockEnvironmentUnitedArabEmirates } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-EnterprisePolicy { return $mockPolicyUae } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Set-EnvironmentEnterprisePolicy { return $script:mockLinkResponse } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Wait-EnterprisePolicyOperation { return "Succeeded" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $result = Enable-SubnetInjection `
+                -EnvironmentId $script:testEnvironmentId `
+                -PolicyArmId $script:testPolicyArmId
+
+            $result | Should -Be $true
+        }
     }
 }


### PR DESCRIPTION
## Summary

`Enable-SubnetInjection` validates that the environment location matches the enterprise policy location before linking. The environment reports the UAE geography as `unitedarabemirates`, while the enterprise policy's Azure resource location is `uae`. These refer to the same geography, but the validation's compatibility allowlist only covered `unitedstates`/`unitedstateseuap` and `unitedkingdom`/`uk` — so a valid UAE link was rejected with:

> Environment location 'unitedarabemirates' does not match the enterprise policy location 'uae'

This adds the `unitedarabemirates` ↔ `uae` pair to the allowlist, mirroring the existing `unitedkingdom` ↔ `uk` handling.

## Why only UAE

Reviewed all enterprise-policy location keys in `Private/VnetValidations.ps1`. The only short-form abbreviations are `uk` and `uae`; every other geo key is a full word that matches the environment's `.location` directly. So UK and UAE were the only abbreviation mismatches, and both are now handled.

## Changes

- `Public/SubnetInjection/Enable-SubnetInjection.ps1` — add `unitedarabemirates`/`uae` to the location compatibility allowlist.
- `Tests/Enable-SubnetInjection.Tests.ps1` — add a UAE compatibility test mirroring the existing UK test.

## Testing

Ran the full Pester suite in both PowerShell Core and Windows PowerShell. The new UAE test passes in both. (Pre-existing, unrelated CRLF "header disclaimer" failures appear locally for every module file because this working tree is checked out with LF endings; CI checks out CRLF.)