### PR TITLE
Update subnet injection location check to allow backend validation

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
@@ -141,23 +141,17 @@ function Enable-SubnetInjection {
 
     Write-Verbose "Enterprise policy SystemId: $policySystemId"
 
-    # Validate that the environment location matches the policy location
+    # Validate location parity as a best-effort pre-check.
+    # Some clouds can expose different normalized strings between environment and policy APIs.
+    # Backend validation remains the source of truth, so do not fail early here.
     $environmentLocation = $environment.location
     $policyLocation = $policy.Location
 
     if ($environmentLocation -ine $policyLocation) {
-        if( ($environmentLocation -eq "unitedstates" -and $policyLocation -eq "unitedstateseuap") -or
-            ($environmentLocation -eq "unitedkingdom" -and $policyLocation -eq "uk") -or
-            ($environmentLocation -eq "unitedarabemirates" -and $policyLocation -eq "uae") -or
-            ($environmentLocation -eq "usgovhigh" -and $policyLocation -eq "usgov") ) {
-            Write-Verbose "Environment is in '$environmentLocation' and policy is in '$policyLocation'. Treating locations as compatible."
-        }
-        else {
-            throw "Environment location '$environmentLocation' does not match the enterprise policy location '$policyLocation'. The environment and policy must be in the same location."
-        }
+        Write-Warning "Environment location '$environmentLocation' differs from enterprise policy location '$policyLocation'. Continuing and relying on backend validation."
     }
 
-    Write-Verbose "Environment location '$environmentLocation' matches policy location '$policyLocation'"
+    Write-Verbose "Location pre-check complete. Environment location: '$environmentLocation'. Policy location: '$policyLocation'."
 
     # Link the policy to the environment
     Write-Verbose "Enabling Subnet Injection for environment..."

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
@@ -148,7 +148,8 @@ function Enable-SubnetInjection {
     if ($environmentLocation -ine $policyLocation) {
         if( ($environmentLocation -eq "unitedstates" -and $policyLocation -eq "unitedstateseuap") -or
             ($environmentLocation -eq "unitedkingdom" -and $policyLocation -eq "uk") -or
-            ($environmentLocation -eq "unitedarabemirates" -and $policyLocation -eq "uae") ) {
+            ($environmentLocation -eq "unitedarabemirates" -and $policyLocation -eq "uae") -or
+            ($environmentLocation -eq "usgovhigh" -and $policyLocation -eq "usgov") ) {
             Write-Verbose "Environment is in '$environmentLocation' and policy is in '$policyLocation'. Treating locations as compatible."
         }
         else {

--- a/Source/Tests/Enable-SubnetInjection.Tests.ps1
+++ b/Source/Tests/Enable-SubnetInjection.Tests.ps1
@@ -285,6 +285,37 @@ Describe 'Enable-SubnetInjection Tests' {
             $result | Should -Be $true
         }
 
+        It 'Should treat usgovhigh environment with usgov policy as compatible' {
+            $mockEnvironmentUsGovHigh = [PSCustomObject]@{
+                name = $script:testEnvironmentId
+                location = "usgovhigh"
+                properties = @{
+                    enterprisePolicies = $null
+                }
+            }
+            $mockPolicyUsGov = [PSCustomObject]@{
+                ResourceId = $script:testPolicyArmId
+                Name = $script:testPolicyName
+                Kind = "NetworkInjection"
+                Location = "usgov"
+                Properties = @{
+                    systemId = $script:testPolicySystemId
+                }
+            }
+
+            Mock Connect-Azure { return $true } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-PPEnvironment { return $mockEnvironmentUsGovHigh } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Get-EnterprisePolicy { return $mockPolicyUsGov } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Set-EnvironmentEnterprisePolicy { return $script:mockLinkResponse } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Wait-EnterprisePolicyOperation { return "Succeeded" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+            $result = Enable-SubnetInjection `
+                -EnvironmentId $script:testEnvironmentId `
+                -PolicyArmId $script:testPolicyArmId
+
+            $result | Should -Be $true
+        }
+
         It 'Should treat unitedarabemirates environment with uae policy as compatible' {
             $mockEnvironmentUnitedArabEmirates = [PSCustomObject]@{
                 name = $script:testEnvironmentId

--- a/Source/Tests/Enable-SubnetInjection.Tests.ps1
+++ b/Source/Tests/Enable-SubnetInjection.Tests.ps1
@@ -213,14 +213,21 @@ Describe 'Enable-SubnetInjection Tests' {
                 -PolicyArmId $script:testPolicyArmId } | Should -Throw "*not a Subnet Injection*"
         }
 
-        It 'Should throw when environment location does not match policy location' {
+        It 'Should continue when environment location does not match policy location' {
             Mock Connect-Azure { return $true } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
             Mock Get-PPEnvironment { return $script:mockEnvironmentDifferentLocation } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
             Mock Get-EnterprisePolicy { return $script:mockPolicy } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Set-EnvironmentEnterprisePolicy { return $script:mockLinkResponse } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+            Mock Wait-EnterprisePolicyOperation { return "Succeeded" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
 
-            { Enable-SubnetInjection `
+            $result = Enable-SubnetInjection `
                 -EnvironmentId $script:testEnvironmentId `
-                -PolicyArmId $script:testPolicyArmId } | Should -Throw "*does not match*"
+                -PolicyArmId $script:testPolicyArmId
+
+            $result | Should -Be $true
+            Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+                $Message -like "*differs from enterprise policy location*"
+            } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
         }
 
         It 'Should treat unitedstates environment with unitedstateseuap policy as compatible' {


### PR DESCRIPTION
Updates  Enable-SubnetInjection  so environment/policy location mismatches no longer fail early when the backend can validate compatibility. The cmdlet now warns on location differences and continues with linking, which supports normalized location pairs across clouds.
