### PR TITLE
Use CFS feed for Official pipeline release

### DIFF
--- a/.pipelines/azure-pipelines-official.yml
+++ b/.pipelines/azure-pipelines-official.yml
@@ -176,21 +176,33 @@ extends:
 
           - task: Powershell@2
             displayName: '🛳️ Release module to PSGallery'
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
               targetType: "inline"
               script: |
                 Write-Host 'Listing artifacts'
                 Get-ChildItem -Path $(Pipeline.Workspace) -Recurse -Name
+
+                [string]$PackageSource = "https://dynamicscrm.pkgs.visualstudio.com/DefaultCollection/_packaging/CommonDataServices/nuget/v2"
+                [string]$PackageSourceName = "CommonDataServices"
+
                 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-                # PSGallery may get disabled prior due to netiso and CFS requirements. Re-register it here.
-                Register-PSRepository -Default
+
+                $patToken = $env:SYSTEM_ACCESSTOKEN | ConvertTo-SecureString -AsPlainText -Force
+                $credentialsObject = New-Object System.Management.Automation.PSCredential("AUTH_TOKEN", $patToken)
+
+                $repository = Get-PSRepository -Name $PackageSourceName -ErrorAction SilentlyContinue
+                if ($null -eq $repository) {
+                  Register-PSRepository -Name $PackageSourceName `
+                    -SourceLocation $PackageSource `
+                    -PublishLocation $PackageSource `
+                    -InstallationPolicy Trusted `
+                    -Credential $credentialsObject `
+                    -Verbose
+                }
+
                 cd '$(Pipeline.Workspace)/drop'
                 Expand-Archive -Path Microsoft.PowerPlatform.EnterprisePolicies_$(Build.BuildNumber).zip -DestinationPath .\Microsoft.PowerPlatform.EnterprisePolicies
-                Write-Host 'Publishing Microsoft.PowerPlatform.EnterprisePolicies module to PSGallery'
-                Publish-Module -Path .\Microsoft.PowerPlatform.EnterprisePolicies -NuGetApiKey $(PowerShellGallery-PublishKey) -Force -Verbose -Repository PSGallery
-                # Disable PSGallery again
-                $psGallery = Get-PSRepository -Name "PSGallery" -ErrorAction SilentlyContinue
-                if ($null -ne $psGallery) {
-                  Write-Output "##[debug] Removing default PS Gallery" # To satisfy network isolation
-                  Unregister-PSRepository -Name $psGallery.Name -ErrorAction SilentlyContinue -Verbose
-                }
+                Write-Host 'Publishing Microsoft.PowerPlatform.EnterprisePolicies module to CommonDataServices'
+                Publish-Module -Path .\Microsoft.PowerPlatform.EnterprisePolicies -Repository $PackageSourceName -Credential $credentialsObject -Force -Verbose

--- a/.pipelines/azure-pipelines-official.yml
+++ b/.pipelines/azure-pipelines-official.yml
@@ -175,7 +175,7 @@ extends:
                 }
 
           - task: Powershell@2
-            displayName: '🛳️ Release module to PSGallery'
+            displayName: '🛳️ Release module to CommonDataServices'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
@@ -188,6 +188,11 @@ extends:
                 [string]$PackageSourceName = "CommonDataServices"
 
                 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+                if ([string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+                  Write-Error 'SYSTEM_ACCESSTOKEN is not available. Enable OAuth token access for this job before publishing to CommonDataServices.'
+                  exit 1
+                }
 
                 $patToken = $env:SYSTEM_ACCESSTOKEN | ConvertTo-SecureString -AsPlainText -Force
                 $credentialsObject = New-Object System.Management.Automation.PSCredential("AUTH_TOKEN", $patToken)


### PR DESCRIPTION
## Summary

Updating **Official** pipeline by keeping the release path on CFS feed

## What changed

In the `Release_PSGallery` job's final publish step, this PR:

- passes `$(System.AccessToken)` into the step
- recreates the `CommonDataServices` repository credential in that step
- registers `CommonDataServices` only if it is missing
- removes `Register-PSRepository -Default`
- replaces `Publish-Module ... -Repository PSGallery -NuGetApiKey ...` with `Publish-Module ... -Repository CommonDataServices -Credential $credentialsObject`

## Why

The pipeline already removes `PSGallery` and registers the `CommonDataServices` feed. This update keeps the full Official release path on the approved feed.

## Validation

- reviewed the Official pipeline diff
- confirmed the existing PR-branch CFS work does not modify `.pipelines/azure-pipelines-official.yml`
- ran local diff/syntax validation for the updated inline PowerShell