### PR TITLE
Register Microsoft.PowerPlatform provider only, not enterprisePoliciesPreview feature +semver:minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The summaries below give a quick overview of each cmdlet. For full parameter lis
 
 ### How to run the Azure subscription setup script
 
-This script registers the Azure subscription for Microsoft.PowerPlatform resource provider and also allowlists the subscription for enterprisePoliciesPreview feature. This will allow you to create and manage enterprise policies in the registered subscription for use with Power Platform.
+This script registers the Azure subscription for the Microsoft.PowerPlatform resource provider. This will allow you to create and manage enterprise policies in the registered subscription for use with Power Platform.
 
 Script name: [SetupSubscriptionForPowerPlatform.ps1](./Source/SetupSubscriptionForPowerPlatform.ps1)
 

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/AzHelper.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/AzHelper.ps1
@@ -103,64 +103,6 @@ function Register-ResourceProvider {
     }
 }
 
-function Register-ProviderFeature {
-    <#
-    .SYNOPSIS
-    Registers an Azure provider feature if it is not already registered.
-
-    .DESCRIPTION
-    Checks if the specified Azure provider feature is registered.
-    If not registered, initiates feature registration.
-
-    .PARAMETER FeatureName
-    The name of the feature to register (e.g., "enterprisePoliciesPreview")
-
-    .PARAMETER ProviderNamespace
-    The namespace of the provider that owns the feature (e.g., "Microsoft.PowerPlatform")
-
-    .EXAMPLE
-    Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]$FeatureName,
-
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        [string]$ProviderNamespace
-    )
-
-    Write-Verbose "Checking $FeatureName feature registration status for $ProviderNamespace..."
-    
-    try {
-        $feature = Get-AzProviderFeature -FeatureName $FeatureName -ProviderNamespace $ProviderNamespace -ErrorAction SilentlyContinue
-        
-        if ($feature -and $feature.RegistrationState -eq "Registered") {
-            Write-Verbose "Feature $FeatureName for $ProviderNamespace is already registered"
-            return $true
-        }
-
-        Write-Host "Registering the subscription for feature $FeatureName for $ProviderNamespace" -ForegroundColor Yellow
-        
-        $register = Register-AzProviderFeature -FeatureName $FeatureName -ProviderNamespace $ProviderNamespace -ErrorAction Stop
-        
-        if ($null -eq $register -or $null -eq $register.RegistrationState) {
-            $registerString = $register | ConvertTo-Json
-            Write-Host "Registration failed for feature $FeatureName for $ProviderNamespace. $registerString" -ForegroundColor Red
-            return $false
-        }
-
-        Write-Host "Subscription registered for feature $FeatureName for $ProviderNamespace" -ForegroundColor Green
-        return $true
-    }
-    catch {
-        Write-Host "Error registering feature $FeatureName for $ProviderNamespace : $($_.Exception.Message)" -ForegroundColor Red
-        return $false
-    }
-}
-
 function Initialize-SubscriptionForPowerPlatform {
     [CmdletBinding()]
     param (
@@ -177,10 +119,6 @@ function Initialize-SubscriptionForPowerPlatform {
     }
     if(-not(Register-ResourceProvider -ProviderNamespace "Microsoft.PowerPlatform")) {
         Write-Host "Failed to register Microsoft.PowerPlatform resource provider" -ForegroundColor Red
-        return $false
-    }
-    if(-not(Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform")) {
-        Write-Host "Failed to register enterprisePoliciesPreview feature for Microsoft.PowerPlatform" -ForegroundColor Red
         return $false
     }
     Add-ValidatedSubscriptionToCache -SubscriptionId $SubscriptionId

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/New-IdentityEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/New-IdentityEnterprisePolicy.ps1
@@ -71,7 +71,7 @@ function New-IdentityEnterprisePolicy {
     $null = Set-AzContext -Subscription $SubscriptionId
 
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
-        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform, Microsoft.Network and the enterprisePoliciesPreview feature is enabled."
+        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."
     }
 
     $body = New-EnterprisePolicyBody -PolicyType ([PolicyType]::Identity) -PolicyLocation $PolicyLocation -PolicyName $PolicyName

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Remove-IdentityEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Remove-IdentityEnterprisePolicy.ps1
@@ -108,7 +108,7 @@ function Remove-IdentityEnterprisePolicy {
 
     # Verify subscription is initialized for Power Platform
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
-        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform, Microsoft.Network and the enterprisePoliciesPreview feature is enabled."
+        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."
     }
 
     # Get the policies based on parameter set

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-SubnetInjectionEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-SubnetInjectionEnterprisePolicy.ps1
@@ -83,7 +83,7 @@ function New-SubnetInjectionEnterprisePolicy{
     $null = Set-AzContext -Subscription $SubscriptionId
 
     if(-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
-        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform, Microsoft.Network and the enterprisePoliciesPreview feature is enabled."
+        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."
     }
 
     $vnets = @()

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-VnetForSubnetDelegation.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-VnetForSubnetDelegation.ps1
@@ -93,7 +93,7 @@ function New-VnetForSubnetDelegation {
     $null = Set-AzContext -Subscription $SubscriptionId
 
     if(-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
-        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform, Microsoft.Network and the enterprisePoliciesPreview feature is enabled."
+        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."
     }
 
     if ($CreateVirtualNetwork) {

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Remove-SubnetInjectionEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Remove-SubnetInjectionEnterprisePolicy.ps1
@@ -107,7 +107,7 @@ function Remove-SubnetInjectionEnterprisePolicy{
 
     # Verify subscription is initialized for Power Platform
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
-        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform, Microsoft.Network and the enterprisePoliciesPreview feature is enabled."
+        throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."
     }
 
     # Get the policies based on parameter set

--- a/Source/SetupSubscriptionForPowerPlatform.ps1
+++ b/Source/SetupSubscriptionForPowerPlatform.ps1
@@ -43,16 +43,5 @@ function SetupSubscriptionForPowerPlatform
         }
         Write-Host "Subscription registered for Microsoft.PowerPlatform" 
     }
-    
-    #Enable the feature
-    Write-Host "Registering the subscription for feature enterprisePoliciesPreview for Microsoft.PowerPlatform"
-    $register = Register-AzProviderFeature -FeatureName enterprisePoliciesPreview -ProviderNamespace Microsoft.PowerPlatform
-    if ($null -eq $register -or $null -eq $register.RegistrationState)
-    {
-        $registerString = $register | ConvertTo-Json
-        Write-Host "Registration failed for feature enterprisePoliciesPreview for subscription $subscription $registerString" -ForegroundColor Red
-        return
-    }
-    Write-Host "Subscription registered for feature enterprisePoliciesPreview for Microsoft.PowerPlatform"        
 }
 SetupSubscriptionForPowerPlatform

--- a/Source/Tests/AzHelper.Tests.ps1
+++ b/Source/Tests/AzHelper.Tests.ps1
@@ -196,105 +196,10 @@ Describe 'AzHelper Tests' {
             }
         }
 
-        Context 'Register-ProviderFeature' {
-            It 'Returns true when feature is already registered' {
-                Mock Get-AzProviderFeature {
-                    return [PSCustomObject]@{
-                        FeatureName = "enterprisePoliciesPreview"
-                        ProviderName = "Microsoft.PowerPlatform"
-                        RegistrationState = "Registered"
-                    }
-                }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $true
-                Should -Invoke Get-AzProviderFeature -Times 1
-            }
-
-            It 'Registers feature when not registered' {
-                Mock Get-AzProviderFeature { return $null }
-                Mock Register-AzProviderFeature {
-                    return [PSCustomObject]@{
-                        FeatureName = "enterprisePoliciesPreview"
-                        ProviderName = "Microsoft.PowerPlatform"
-                        RegistrationState = "Registered"
-                    }
-                }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $true
-                Should -Invoke Register-AzProviderFeature -Times 1
-            }
-
-            It 'Registers feature when registration state is not Registered' {
-                Mock Get-AzProviderFeature {
-                    return [PSCustomObject]@{
-                        FeatureName = "enterprisePoliciesPreview"
-                        ProviderName = "Microsoft.PowerPlatform"
-                        RegistrationState = "NotRegistered"
-                    }
-                }
-                Mock Register-AzProviderFeature {
-                    return [PSCustomObject]@{
-                        FeatureName = "enterprisePoliciesPreview"
-                        ProviderName = "Microsoft.PowerPlatform"
-                        RegistrationState = "Registering"
-                    }
-                }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $true
-            }
-
-            It 'Returns false when Register-AzProviderFeature returns null' {
-                Mock Get-AzProviderFeature { return $null }
-                Mock Register-AzProviderFeature { return $null }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $false
-            }
-
-            It 'Returns false when Register-AzProviderFeature has no RegistrationState' {
-                Mock Get-AzProviderFeature { return $null }
-                Mock Register-AzProviderFeature {
-                    return [PSCustomObject]@{
-                        FeatureName = "enterprisePoliciesPreview"
-                        ProviderName = "Microsoft.PowerPlatform"
-                    }
-                }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $false
-            }
-
-            It 'Returns false when Get-AzProviderFeature throws exception' {
-                Mock Get-AzProviderFeature { throw "Network error" }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $false
-            }
-
-            It 'Returns false when Register-AzProviderFeature throws exception' {
-                Mock Get-AzProviderFeature { return $null }
-                Mock Register-AzProviderFeature { throw "Registration failed" }
-
-                $result = Register-ProviderFeature -FeatureName "enterprisePoliciesPreview" -ProviderNamespace "Microsoft.PowerPlatform"
-
-                $result | Should -Be $false
-            }
-        }
-
         Context 'Initialize-SubscriptionForPowerPlatform' {
             It 'Returns true when subscription is already validated' {
                 Mock Test-SubscriptionValidated { return $true }
                 Mock Register-ResourceProvider { return $true }
-                Mock Register-ProviderFeature { return $true }
                 Mock Add-ValidatedSubscriptionToCache {}
 
                 $result = Initialize-SubscriptionForPowerPlatform -SubscriptionId "sub-123"
@@ -302,21 +207,18 @@ Describe 'AzHelper Tests' {
                 $result | Should -Be $true
                 Should -Invoke Test-SubscriptionValidated -Times 1
                 Should -Invoke Register-ResourceProvider -Times 0
-                Should -Invoke Register-ProviderFeature -Times 0
                 Should -Invoke Add-ValidatedSubscriptionToCache -Times 0
             }
 
-            It 'Registers all required providers and features for new subscription' {
+            It 'Registers all required providers for new subscription' {
                 Mock Test-SubscriptionValidated { return $false }
                 Mock Register-ResourceProvider { return $true }
-                Mock Register-ProviderFeature { return $true }
                 Mock Add-ValidatedSubscriptionToCache {}
 
                 $result = Initialize-SubscriptionForPowerPlatform -SubscriptionId "sub-456"
 
                 $result | Should -Be $true
                 Should -Invoke Register-ResourceProvider -Times 2
-                Should -Invoke Register-ProviderFeature -Times 1
                 Should -Invoke Add-ValidatedSubscriptionToCache -Times 1
             }
 
@@ -330,7 +232,6 @@ Describe 'AzHelper Tests' {
                     }
                     return $true
                 }
-                Mock Register-ProviderFeature { return $true }
                 Mock Add-ValidatedSubscriptionToCache {}
 
                 $result = Initialize-SubscriptionForPowerPlatform -SubscriptionId "sub-789"
@@ -349,7 +250,6 @@ Describe 'AzHelper Tests' {
                     }
                     return $true
                 }
-                Mock Register-ProviderFeature { return $true }
                 Mock Add-ValidatedSubscriptionToCache {}
 
                 $result = Initialize-SubscriptionForPowerPlatform -SubscriptionId "sub-abc"
@@ -358,22 +258,9 @@ Describe 'AzHelper Tests' {
                 Should -Invoke Add-ValidatedSubscriptionToCache -Times 0
             }
 
-            It 'Returns false when feature registration fails' {
-                Mock Test-SubscriptionValidated { return $false }
-                Mock Register-ResourceProvider { return $true }
-                Mock Register-ProviderFeature { return $false }
-                Mock Add-ValidatedSubscriptionToCache {}
-
-                $result = Initialize-SubscriptionForPowerPlatform -SubscriptionId "sub-def"
-
-                $result | Should -Be $false
-                Should -Invoke Add-ValidatedSubscriptionToCache -Times 0
-            }
-
             It 'Adds subscription to cache after successful initialization' {
                 Mock Test-SubscriptionValidated { return $false }
                 Mock Register-ResourceProvider { return $true }
-                Mock Register-ProviderFeature { return $true }
                 Mock Add-ValidatedSubscriptionToCache {}
                 $subscriptionId = "sub-ghi"
 

--- a/Source/Tests/FakeAzModule/Fake-AzModuleFunctions.psm1
+++ b/Source/Tests/FakeAzModule/Fake-AzModuleFunctions.psm1
@@ -53,8 +53,6 @@ function Get-AzResource {
 function New-AzResourceGroupDeployment {}
 function Get-AzResourceProvider {}
 function Register-AzResourceProvider {}
-function Get-AzProviderFeature {}
-function Register-AzProviderFeature {}
 function Remove-AzResource {
     param(
         [string]$ResourceId,


### PR DESCRIPTION
## Summary

The subscription setup no longer registers the `enterprisePoliciesPreview` provider feature. It now registers only the `Microsoft.PowerPlatform` resource provider (alongside `Microsoft.Network`), since only the provider is required.

## Changes

- **Private/AzHelper.ps1** (active module): removed the `Register-ProviderFeature` function and its call in `Initialize-SubscriptionForPowerPlatform`. Subscription init now registers only the `Microsoft.Network` and `Microsoft.PowerPlatform` providers.
- **Public cmdlets** (New-/Remove-SubnetInjectionEnterprisePolicy, New-/Remove-IdentityEnterprisePolicy, New-VnetForSubnetDelegation): updated the initialization-failure error message to drop the preview-feature mention.
- **Tests/AzHelper.Tests.ps1**: removed the `Register-ProviderFeature` test suite and feature-registration references from the `Initialize-SubscriptionForPowerPlatform` tests.
- **Tests/FakeAzModule/Fake-AzModuleFunctions.psm1**: removed the now-unused `Get-AzProviderFeature` / `Register-AzProviderFeature` stubs.
- **Legacy SetupSubscriptionForPowerPlatform.ps1** and **README.md**: removed the preview-feature registration/description for consistency.

## Testing

- PowerShell Core (pwsh): **384 passed, 0 failed** - Build Succeeded
- Windows PowerShell (powershell): **384 passed, 0 failed** - Build Succeeded

No docs regeneration needed (comment-based help untouched).