### PR TITLE
Validate subscription access before switching Azure context

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/AzHelper.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/AzHelper.ps1
@@ -7,6 +7,37 @@ THE ENTIRE RISK OF THE USE OR THE RESULTS FROM THE USE OF THIS SAMPLE CODE REMAI
 NO TECHNICAL SUPPORT IS PROVIDED. YOU MAY NOT DISTRIBUTE THIS CODE UNLESS YOU HAVE A LICENSE AGREEMENT WITH MICROSOFT THAT ALLOWS YOU TO DO SO.
 #>
 
+function Set-SubscriptionContext {
+    <#
+    .SYNOPSIS
+    Validates access to an Azure subscription, then makes it the active context.
+
+    .DESCRIPTION
+    Confirms the current Azure context (user or service principal) can at least read the
+    target subscription before switching to it. A service principal that has not been
+    granted access to the subscription cannot resolve it, and Set-AzContext then fails with
+    "Please provide a valid tenant or a valid subscription." Validating access first lets
+    the caller surface a clear, actionable error instead of that opaque failure.
+
+    .PARAMETER SubscriptionId
+    The Azure subscription ID to validate and make current.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$SubscriptionId
+    )
+
+    $subscription = Get-AzSubscription -SubscriptionId $SubscriptionId -ErrorAction SilentlyContinue
+    if ($null -eq $subscription) {
+        $context = Get-AzContext
+        $accountSuffix = if ($null -ne $context -and $null -ne $context.Account) { " (account '$($context.Account.Id)')" } else { "" }
+        throw "The current Azure context$accountSuffix does not have access to subscription '$SubscriptionId'. Ensure the identity has at least Reader access to the subscription."
+    }
+
+    return Set-AzContext -Subscription $SubscriptionId
+}
+
 function Register-ResourceProvider {
     <#
     .SYNOPSIS

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Disable-Identity.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Disable-Identity.ps1
@@ -92,7 +92,7 @@ function Disable-Identity {
     if ($linkedPolicyArmId -match "/subscriptions/([^/]+)/") {
         $subscriptionId = $Matches[1]
         Write-Verbose "Setting subscription context to $subscriptionId"
-        $null = Set-AzContext -Subscription $subscriptionId
+        $null = Set-SubscriptionContext -SubscriptionId $subscriptionId
     }
     else {
         throw "Invalid linked policy ARM ID format: $linkedPolicyArmId"

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Enable-Identity.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Enable-Identity.ps1
@@ -120,7 +120,7 @@ function Enable-Identity {
     $null = $PolicyArmId -match "/subscriptions/([^/]+)/"
     $subscriptionId = $Matches[1]
     Write-Verbose "Setting subscription context to $subscriptionId"
-    $null = Set-AzContext -Subscription $subscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $subscriptionId
 
     # Get the enterprise policy and extract SystemId
     Write-Verbose "Retrieving enterprise policy: $PolicyArmId"

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Get-IdentityEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Get-IdentityEnterprisePolicy.ps1
@@ -90,7 +90,7 @@ function Get-IdentityEnterprisePolicy {
     # Set subscription context for non-ByEnvironment parameter sets
     if ($PSCmdlet.ParameterSetName -ne 'ByEnvironment') {
         Write-Verbose "Setting subscription context to $SubscriptionId"
-        $null = Set-AzContext -Subscription $SubscriptionId
+        $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
     }
 
     # Retrieve policies based on parameter set
@@ -139,7 +139,7 @@ function Get-IdentityEnterprisePolicy {
             # Set subscription context from the policy ARM ID
             if ($policyArmId -match "/subscriptions/([^/]+)/") {
                 Write-Verbose "Setting subscription context to $($Matches[1])"
-                $null = Set-AzContext -Subscription $Matches[1]
+                $null = Set-SubscriptionContext -SubscriptionId $Matches[1]
             }
 
             $policy = Get-EnterprisePolicy -PolicyArmId $policyArmId

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/New-IdentityEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/New-IdentityEnterprisePolicy.ps1
@@ -68,7 +68,7 @@ function New-IdentityEnterprisePolicy {
     }
 
     Write-Verbose "Setting subscription context to $SubscriptionId"
-    $null = Set-AzContext -Subscription $SubscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
 
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
         throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Remove-IdentityEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/Identity/Remove-IdentityEnterprisePolicy.ps1
@@ -104,7 +104,7 @@ function Remove-IdentityEnterprisePolicy {
 
     # Set subscription context
     Write-Verbose "Setting subscription context to $SubscriptionId"
-    $null = Set-AzContext -Subscription $SubscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
 
     # Verify subscription is initialized for Power Platform
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Get-SubnetHistoricalUsage.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Diagnostics/Get-SubnetHistoricalUsage.ps1
@@ -86,7 +86,7 @@ function Get-SubnetHistoricalUsage {
         }
         'ByEnterprisePolicyId' {
             $null = $EnterprisePolicyId -match "/subscriptions/([^/]+)/"
-            $null = Set-AzContext -Subscription $Matches[1]
+            $null = Set-SubscriptionContext -SubscriptionId $Matches[1]
             $policy = Get-EnterprisePolicy -PolicyArmId $EnterprisePolicyId
             if ($null -eq $policy) {
                 throw "Failed to retrieve enterprise policy with ARM ID: $EnterprisePolicyId."
@@ -106,7 +106,7 @@ function Get-SubnetHistoricalUsage {
             }
             $policyArmId = $environment.properties.enterprisePolicies.VNets.id
             $null = $policyArmId -match "/subscriptions/([^/]+)/"
-            $null = Set-AzContext -Subscription $Matches[1]
+            $null = Set-SubscriptionContext -SubscriptionId $Matches[1]
             $policy = Get-EnterprisePolicy -PolicyArmId $policyArmId
             if ($null -eq $policy -or [string]::IsNullOrWhiteSpace($policy.Properties.systemId)) {
                 throw "Could not retrieve enterprise policy details for: $policyArmId."

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Disable-SubnetInjection.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Disable-SubnetInjection.ps1
@@ -92,7 +92,7 @@ function Disable-SubnetInjection {
     if ($linkedPolicyArmId -match "/subscriptions/([^/]+)/") {
         $subscriptionId = $Matches[1]
         Write-Verbose "Setting subscription context to $subscriptionId"
-        $null = Set-AzContext -Subscription $subscriptionId
+        $null = Set-SubscriptionContext -SubscriptionId $subscriptionId
     }
     else {
         throw "Invalid linked policy ARM ID format: $linkedPolicyArmId"

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Enable-SubnetInjection.ps1
@@ -120,7 +120,7 @@ function Enable-SubnetInjection {
     $null = $PolicyArmId -match "/subscriptions/([^/]+)/"
     $subscriptionId = $Matches[1]
     Write-Verbose "Setting subscription context to $subscriptionId"
-    $null = Set-AzContext -Subscription $subscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $subscriptionId
 
     # Get the enterprise policy and extract SystemId
     Write-Verbose "Retrieving enterprise policy: $PolicyArmId"

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Get-SubnetInjectionEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Get-SubnetInjectionEnterprisePolicy.ps1
@@ -95,7 +95,7 @@ function Get-SubnetInjectionEnterprisePolicy{
     # Set subscription context for non-ByEnvironment parameter sets
     if ($PSCmdlet.ParameterSetName -ne 'ByEnvironment') {
         Write-Verbose "Setting subscription context to $SubscriptionId"
-        $null = Set-AzContext -Subscription $SubscriptionId
+        $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
     }
 
     # Retrieve policies based on parameter set
@@ -144,7 +144,7 @@ function Get-SubnetInjectionEnterprisePolicy{
             # Set subscription context from the policy ARM ID
             if ($policyArmId -match "/subscriptions/([^/]+)/") {
                 Write-Verbose "Setting subscription context to $($Matches[1])"
-                $null = Set-AzContext -Subscription $Matches[1]
+                $null = Set-SubscriptionContext -SubscriptionId $Matches[1]
             }
 
             $policy = Get-EnterprisePolicy -PolicyArmId $policyArmId

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-SubnetInjectionEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-SubnetInjectionEnterprisePolicy.ps1
@@ -80,7 +80,7 @@ function New-SubnetInjectionEnterprisePolicy{
     }
 
     Write-Verbose "Setting subscription context to $SubscriptionId"
-    $null = Set-AzContext -Subscription $SubscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
 
     if(-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
         throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-VnetForSubnetDelegation.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/New-VnetForSubnetDelegation.ps1
@@ -90,7 +90,7 @@ function New-VnetForSubnetDelegation {
     }
 
     Write-Verbose "Setting subscription context to $SubscriptionId"
-    $null = Set-AzContext -Subscription $SubscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
 
     if(-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {
         throw "Failed to initialize subscription for Power Platform. Please ensure the subscription is registered for Microsoft.PowerPlatform and Microsoft.Network."

--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Remove-SubnetInjectionEnterprisePolicy.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Public/SubnetInjection/Remove-SubnetInjectionEnterprisePolicy.ps1
@@ -103,7 +103,7 @@ function Remove-SubnetInjectionEnterprisePolicy{
 
     # Set subscription context
     Write-Verbose "Setting subscription context to $SubscriptionId"
-    $null = Set-AzContext -Subscription $SubscriptionId
+    $null = Set-SubscriptionContext -SubscriptionId $SubscriptionId
 
     # Verify subscription is initialized for Power Platform
     if (-not(Initialize-SubscriptionForPowerPlatform -SubscriptionId $SubscriptionId)) {

--- a/Source/Tests/AzHelper.Tests.ps1
+++ b/Source/Tests/AzHelper.Tests.ps1
@@ -10,6 +10,27 @@ Describe 'AzHelper Tests' {
             Mock Start-Sleep {}
         }
 
+        Context 'Set-SubscriptionContext' {
+            It 'Sets the subscription context when the identity can read the subscription' {
+                Mock Get-AzSubscription { return [PSCustomObject]@{ Id = "sub-123"; State = "Enabled" } }
+                Mock Set-AzContext {}
+
+                Set-SubscriptionContext -SubscriptionId "sub-123"
+
+                Should -Invoke Set-AzContext -Times 1 -ParameterFilter { $Subscription -eq "sub-123" }
+            }
+
+            It 'Throws without switching context when the identity cannot access the subscription' {
+                Mock Get-AzSubscription { return $null }
+                Mock Get-AzContext { return [PSCustomObject]@{ Account = [PSCustomObject]@{ Id = "sp-client-id" } } }
+                Mock Set-AzContext {}
+
+                { Set-SubscriptionContext -SubscriptionId "sub-123" } | Should -Throw "*does not have access to subscription 'sub-123'*"
+
+                Should -Invoke Set-AzContext -Times 0
+            }
+        }
+
         Context 'Register-ResourceProvider' {
             It 'Returns true when provider is already registered' {
                 Mock Get-AzResourceProvider {

--- a/Source/Tests/FakeAzModule/Fake-AzModuleFunctions.psm1
+++ b/Source/Tests/FakeAzModule/Fake-AzModuleFunctions.psm1
@@ -31,7 +31,20 @@ function Connect-AzAccount {
     )
 }
 function Get-AzContext {}
-function Set-AzContext {}
+function Set-AzContext {
+    param(
+        $Context,
+        $Subscription
+    )
+}
+function Get-AzSubscription {
+    [CmdletBinding()]
+    param(
+        $SubscriptionId,
+        $TenantId
+    )
+    return [PSCustomObject]@{ Id = $SubscriptionId }
+}
 function Get-AzADAppCredential {}
 function New-AzADAppCredential {}
 function Get-AzADApplication {}


### PR DESCRIPTION
## Summary
A small, self-contained bugfix extracted from #84 so it can be reviewed independently.

### Validate subscription access before switching context
Adds a private `Set-SubscriptionContext` helper that confirms the current Azure context (user **or** service principal) can at least read the target subscription before calling `Set-AzContext`.

**Why:** A service principal that has not been granted access to the subscription cannot resolve it, and `Set-AzContext` then fails with the opaque `Please provide a valid tenant or a valid subscription.` Validating access first lets us surface a clear, actionable error instead.

All Identity and Subnet Injection cmdlets that previously called `Set-AzContext -Subscription` now route through the helper.

## Testing
- `Build` + `Test` pass in **both** PowerShell Core and Windows PowerShell (386 tests, 0 failures).

> Part of splitting the large #84 into focused PRs.