### PR TITLE
Fix Set-EnvironmentEnterprisePolicy BAP endpoint

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/EnvironmentOperations.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/EnvironmentOperations.ps1
@@ -85,7 +85,7 @@ function Set-EnvironmentEnterprisePolicy {
 
     $apiVersion = "2019-10-01"
     $baseUri = Get-PPEndpointUrl -Endpoint $Endpoint
-    $uri = "${baseUri}providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/${EnvironmentId}/enterprisePolicies/${PolicyType}/${Operation}?api-version=${apiVersion}"
+    $uri = "${baseUri}providers/Microsoft.BusinessAppPlatform/environments/${EnvironmentId}/enterprisePolicies/${PolicyType}/${Operation}?api-version=${apiVersion}"
 
     $body = @{ SystemId = $PolicySystemId } | ConvertTo-Json
 

--- a/Source/Tests/EnvironmentOperations.Tests.ps1
+++ b/Source/Tests/EnvironmentOperations.Tests.ps1
@@ -117,7 +117,7 @@ Describe 'EnvironmentOperations Tests' {
                     -Endpoint ([PPEndpoint]::Prod)
 
                 Should -Invoke New-JsonRequestMessage -Times 1 -ParameterFilter {
-                    $Uri -match 'scopes/admin/environments' -and
+                    $Uri -match 'environments' -and
                     $Uri -match 'enterprisePolicies/NetworkInjection/link'
                 }
             }


### PR DESCRIPTION
## Summary
Removes the stale `scopes/admin/` segment from the `environments` URI in `Set-EnvironmentEnterprisePolicy`, so link/unlink requests hit the correct BAP endpoint.

```diff
-.../Microsoft.BusinessAppPlatform/scopes/admin/environments/${EnvironmentId}/enterprisePolicies/...
+.../Microsoft.BusinessAppPlatform/environments/${EnvironmentId}/enterprisePolicies/...
```

Extracted from #84 as a standalone bugfix so it can be reviewed on its own.