### PR TITLE
[skip ci] Regenerate stale cmdlet documentation

### DIFF
--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-EnvironmentHistoricalUsage.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-EnvironmentHistoricalUsage.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 02/17/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Get-EnvironmentHistoricalUsage
 ---
@@ -32,7 +32,7 @@ This cmdlet has the following aliases,
 ## DESCRIPTION
 
 The Get-EnvironmentHistoricalUsage cmdlet retrieves the historical usage of the specified environment.
-This is only the historical usage that the specified environment has.
+This cmdlet only includes the historical usage for the specified environment.
 It doesn't include usage from other environments and it doesn't include any IP addresses that might be reserved by Azure.
 
 ## EXAMPLES

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-IdentityEnterprisePolicy.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-IdentityEnterprisePolicy.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 04/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Get-IdentityEnterprisePolicy
 ---
@@ -53,10 +53,10 @@ This cmdlet has the following aliases,
 ## DESCRIPTION
 
 The Get-IdentityEnterprisePolicy cmdlet retrieves identity enterprise policies using one of four methods:
-- By Resource ID: Retrieves a specific policy using its Azure Resource Manager (ARM) resource ID
-- By Environment: Retrieves the policy linked to a specific Power Platform environment
-- By Subscription: Retrieves all Identity policies in the current subscription
-- By Resource Group: Retrieves all Identity policies in a specific resource group
+- By Resource ID: Retrieves a specific policy using its Azure Resource Manager (ARM) resource ID.
+- By Environment: Retrieves the policy linked to a specific Power Platform environment.
+- By Subscription: Retrieves all identity policies in the current subscription.
+- By Resource Group: Retrieves all identity policies in a specific resource group.
 
 ## EXAMPLES
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-SubnetHistoricalUsage.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-SubnetHistoricalUsage.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 05/11/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Get-SubnetHistoricalUsage
 ---
@@ -13,7 +13,7 @@ title: Get-SubnetHistoricalUsage
 
 ## SYNOPSIS
 
-Retrieves the historical network usage of the subnet backing an enterprise policy, identified by ARM resource ID, linked environment, or system ID.
+Retrieves the historical network usage of the subnet backing an enterprise policy, identified by Azure Resource Manager (ARM) resource ID, linked environment, or system ID.
 
 ## SYNTAX
 
@@ -45,8 +45,8 @@ This cmdlet has the following aliases,
 
 ## DESCRIPTION
 
-Retrieves the historical usage of the subnet backing a Subnet Injection enterprise policy.
-This includes usage from all environments linked to the policy and the IPs reserved by Azure.
+Retrieves the historical usage of the subnet backing a subnet injection enterprise policy.
+This includes usage from all environments linked to the policy and the IP addresses reserved by Azure.
 
 The policy can be identified in three ways:
 - By its Azure ARM resource ID (-EnterprisePolicyId).
@@ -148,7 +148,7 @@ HelpMessage: ''
 
 ### -EnvironmentId
 
-The Power Platform environment ID whose linked policy should be used.
+The Power Platform environment ID whose linked policy to use.
 
 ```yaml
 Type: System.String

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-SubnetInjectionEnterprisePolicy.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Get-SubnetInjectionEnterprisePolicy.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 04/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Get-SubnetInjectionEnterprisePolicy
 ---
@@ -53,10 +53,10 @@ This cmdlet has the following aliases,
 ## DESCRIPTION
 
 The Get-SubnetInjectionEnterprisePolicy cmdlet retrieves subnet injection enterprise policies using one of four methods:
-- By Resource ID: Retrieves a specific policy using its Azure Resource Manager (ARM) resource ID
-- By Environment: Retrieves the policy linked to a specific Power Platform environment
-- By Subscription: Retrieves all Subnet Injection policies in the current subscription
-- By Resource Group: Retrieves all Subnet Injection policies in a specific resource group
+- By Resource ID: Retrieves a specific policy using its Azure Resource Manager (ARM) resource ID.
+- By Environment: Retrieves the policy linked to a specific Power Platform environment.
+- By Subscription: Retrieves all subnet injection policies in the current subscription.
+- By Resource Group: Retrieves all subnet injection policies in a specific resource group.
 
 ## EXAMPLES
 
@@ -258,7 +258,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### Microsoft.Azure.Commands.ResourceManager.Cmdlets.SdkModels.PSResource
 
-Returns PSResource object(s) representing the enterprise policy Azure resources. Throws an error if no policy is found.
+Returns PSResource object(s) representing the enterprise policy Azure resources. Returns an error if no policy is found.
 
 {{ Fill in the Description }}
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Microsoft.PowerPlatform.EnterprisePolicies.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Microsoft.PowerPlatform.EnterprisePolicies.md
@@ -5,7 +5,7 @@ HelpInfoUri:
 Locale: en-US
 Module Guid: fce8ece4-09c1-4455-9253-c68b6c2ea4d6
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 05/11/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Microsoft.PowerPlatform.EnterprisePolicies Module
 ---
@@ -52,7 +52,7 @@ Retrieves identity enterprise policies for Power Platform.
 
 ### [Get-SubnetHistoricalUsage](Get-SubnetHistoricalUsage.md)
 
-Retrieves the historical network usage of the subnet backing an enterprise policy, identified by ARM resource ID, linked environment, or system ID.
+Retrieves the historical network usage of the subnet backing an enterprise policy, identified by Azure Resource Manager (ARM) resource ID, linked environment, or system ID.
 
 ### [Get-SubnetInjectionEnterprisePolicy](Get-SubnetInjectionEnterprisePolicy.md)
 
@@ -92,7 +92,7 @@ Tests the Domain Name System (DNS) resolution for a given hostname in a specifie
 
 ### [Test-NetworkConnectivity](Test-NetworkConnectivity.md)
 
-Tests the connectivity to a given service in a specified environment.
+Tests the connectivity to a given service in the specified environment.
 
 ### [Test-TLSHandshake](Test-TLSHandshake.md)
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Remove-IdentityEnterprisePolicy.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Remove-IdentityEnterprisePolicy.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 04/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Remove-IdentityEnterprisePolicy
 ---
@@ -56,8 +56,9 @@ The Remove-IdentityEnterprisePolicy cmdlet removes an identity enterprise policy
 When using BySubscription or ByResourceGroup, if multiple policies are found, the cmdlet outputs the policy ARM IDs.
 You can specify which policy to remove using -PolicyResourceId.
 
-Note: A policy can't be deleted if it's associated with any Power Platform environments.
-Unlink the policy from all environments before attempting to remove it.
+Note:
+- A policy can't be deleted if it's associated with any Power Platform environments.
+- Unlink the policy from all environments before attempting to remove it.
 
 ## EXAMPLES
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Remove-SubnetInjectionEnterprisePolicy.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Remove-SubnetInjectionEnterprisePolicy.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 04/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Remove-SubnetInjectionEnterprisePolicy
 ---
@@ -305,7 +305,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### Returns nothing on success. Throws an error if no policy is found or removal fails.
+### Returns nothing on success. Returns an error if no policy is found or removal fails.
 When multiple policies are found
 
 {{ Fill in the Description }}

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-DnsResolution.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-DnsResolution.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 05/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Test-DnsResolution
 ---
@@ -33,7 +33,7 @@ This cmdlet has the following aliases,
 
 The Test-DnsResolution cmdlet tests the DNS resolution for a given hostname in a specified environment.
 This cmdlet is executed in the context of your delegated subnet in the region that you have specified.
-If the region is not specified, it defaults to the region of the environment.
+If the region isn't specified, it defaults to the region of the environment.
 
 ## EXAMPLES
 

--- a/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-NetworkConnectivity.md
+++ b/docs/en-US/Microsoft.PowerPlatform.EnterprisePolicies/Test-NetworkConnectivity.md
@@ -4,7 +4,7 @@ external help file: Microsoft.PowerPlatform.EnterprisePolicies-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: Microsoft.PowerPlatform.EnterprisePolicies
-ms.date: 05/07/2026
+ms.date: 08/02/2026
 PlatyPS schema version: 2024-05-01
 title: Test-NetworkConnectivity
 ---
@@ -13,7 +13,7 @@ title: Test-NetworkConnectivity
 
 ## SYNOPSIS
 
-Tests the connectivity to a given service in a specified environment.
+Tests the connectivity to a given service in the specified environment.
 
 ## SYNTAX
 
@@ -32,7 +32,7 @@ This cmdlet has the following aliases,
 
 ## DESCRIPTION
 
-The Test-NetworkConnectivity cmdlet tests the connectivity to a given service in a specified environment.
+The Test-NetworkConnectivity cmdlet tests the connectivity to a given service in the specified environment.
 The connectivity test attempts to establish a TCP connection to the specified destination on the specified port.
 The cmdlet is executed in the context of your delegated subnet in the region that you specify.
 If the region isn't specified, it defaults to the region of the environment.


### PR DESCRIPTION
## Summary
Regenerates cmdlet documentation via `BuildHelp` so the `docs/` folder matches the comment-based help currently in the source. No code changes.

The docs had drifted: this refreshes `ms.date` stamps and picks up help-text edits (wording/casing/punctuation) that were made in the source but never regenerated.

Doing this on its own first keeps the upcoming feature PRs' doc diffs limited to their new cmdlets.