### PR TITLE
Fix enterprise policy link/unlink 404 

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/EnvironmentOperations.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/EnvironmentOperations.ps1
@@ -85,7 +85,7 @@ function Set-EnvironmentEnterprisePolicy {
 
     $apiVersion = "2019-10-01"
     $baseUri = Get-PPEndpointUrl -Endpoint $Endpoint
-    $uri = "${baseUri}providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/${EnvironmentId}/enterprisePolicies/${PolicyType}/${Operation}?api-version=${apiVersion}"
+    $uri = "${baseUri}providers/Microsoft.BusinessAppPlatform/environments/${EnvironmentId}/enterprisePolicies/${PolicyType}/${Operation}?api-version=${apiVersion}"
 
     $body = @{ SystemId = $PolicySystemId } | ConvertTo-Json
 

--- a/Source/Tests/EnvironmentOperations.Tests.ps1
+++ b/Source/Tests/EnvironmentOperations.Tests.ps1
@@ -117,8 +117,53 @@ Describe 'EnvironmentOperations Tests' {
                     -Endpoint ([PPEndpoint]::Prod)
 
                 Should -Invoke New-JsonRequestMessage -Times 1 -ParameterFilter {
-                    $Uri -match 'scopes/admin/environments' -and
-                    $Uri -match 'enterprisePolicies/NetworkInjection/link'
+                    $Uri -eq "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/$script:testEnvironmentId/enterprisePolicies/NetworkInjection/link?api-version=2019-10-01"
+                }
+            }
+
+            It 'Should not use an admin-scoped path for link or unlink' {
+                Mock Send-RequestWithRetries {
+                    $null = & $RequestFactory
+                    return $mock202Result
+                }
+                Mock New-JsonRequestMessage {
+                    param($Uri, $AccessToken, $Content, $HttpMethod)
+                    return [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Post, $Uri)
+                }
+
+                Set-EnvironmentEnterprisePolicy `
+                    -EnvironmentId $script:testEnvironmentId `
+                    -PolicyType ([PolicyType]::NetworkInjection) `
+                    -PolicySystemId $script:testPolicySystemId `
+                    -Operation ([LinkOperation]::unlink) `
+                    -Endpoint ([PPEndpoint]::Prod)
+
+                Should -Invoke New-JsonRequestMessage -Times 1 -ParameterFilter {
+                    $Uri -notmatch 'scopes/' -and
+                    $Uri -eq "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/$script:testEnvironmentId/enterprisePolicies/NetworkInjection/unlink?api-version=2019-10-01"
+                }
+            }
+
+            It 'Should build the link URL from the shared endpoint mapping for GCCH' {
+                Mock Get-PPEndpointUrl { return "https://high.api.bap.microsoft.us/" }
+                Mock Send-RequestWithRetries {
+                    $null = & $RequestFactory
+                    return $mock202Result
+                }
+                Mock New-JsonRequestMessage {
+                    param($Uri, $AccessToken, $Content, $HttpMethod)
+                    return [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Post, $Uri)
+                }
+
+                Set-EnvironmentEnterprisePolicy `
+                    -EnvironmentId $script:testEnvironmentId `
+                    -PolicyType ([PolicyType]::NetworkInjection) `
+                    -PolicySystemId $script:testPolicySystemId `
+                    -Operation ([LinkOperation]::link) `
+                    -Endpoint ([PPEndpoint]::usgovhigh)
+
+                Should -Invoke New-JsonRequestMessage -Times 1 -ParameterFilter {
+                    $Uri -eq "https://high.api.bap.microsoft.us/providers/Microsoft.BusinessAppPlatform/environments/$script:testEnvironmentId/enterprisePolicies/NetworkInjection/link?api-version=2019-10-01"
                 }
             }
 

--- a/Source/Tests/RESTHelpers.Tests.ps1
+++ b/Source/Tests/RESTHelpers.Tests.ps1
@@ -22,6 +22,13 @@ Describe 'RESTHelpers Tests' {
             }
         }
     
+        Context 'Testing Get-PPEndpointUrl' {
+            It 'Returns the GCCH BAP host used by all GCCH call paths' {
+                $result = Get-PPEndpointUrl -Endpoint ([PPEndpoint]::usgovhigh)
+                $result | Should -Be "https://high.api.bap.microsoft.us/"
+            }
+        }
+    
         Context 'Testing Get-EnvironmentRouteHostName' {
             It 'Returns the correct route for TIP1 endpoint' {
                 $result = Get-EnvironmentRouteHostName -EnvironmentId "12345678-1234-1234-1234-123456789012" -Endpoint ([PPEndpoint]::tip1)


### PR DESCRIPTION
## Summary


This fixes the 404 returned by `Enable-SubnetInjection` when `Set-EnvironmentEnterprisePolicy` calls the enterprise policy `link`/`unlink` route.


## Root cause


`Set-EnvironmentEnterprisePolicy` was building the URI with an extra `scopes/admin` segment:


`providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/{environmentId}/enterprisePolicies/{policyType}/{operation}`


That route is not registered for enterprise policy link/unlink. The valid route is:


`providers/Microsoft.BusinessAppPlatform/environments/{environmentId}/enterprisePolicies/{policyType}/{operation}`


`Get-PPEnvironment` correctly uses `scopes/admin`, but `Set-EnvironmentEnterprisePolicy` should not.


## Changes



- Update `Set-EnvironmentEnterprisePolicy` to call the unscoped enterprise policy route

- Keep `Get-PPEndpointUrl` behavior unchanged for all endpoints/clouds

- Add regression coverage for:

- prod link URL

- GCCH using the existing shared BAP host mapping

- unlink path not including any `scopes/` segment

- shared `Get-PPEndpointUrl([PPEndpoint]::usgovhigh)` mapping remaining unchanged



## Validation



- Full test run on `origin/main` baseline: `366 passed / 18 failed`

- Full test run with this fix: `369 passed / 18 failed`