### PR TITLE
Fix "header not found" error when a response omits x-ms-correlation-id

### DIFF
--- a/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/RESTHelpers.ps1
+++ b/Source/Microsoft.PowerPlatform.EnterprisePolicies/Private/RESTHelpers.ps1
@@ -268,6 +268,29 @@ function Get-APIResourceUrl {
     }
 }
 
+function Get-CorrelationId {
+    <#
+    .SYNOPSIS
+    Safely extracts the x-ms-correlation-id header from an HTTP response.
+
+    .DESCRIPTION
+    Returns the first x-ms-correlation-id header value if present, otherwise an empty string.
+    HttpHeaders.GetValues throws "The given header was not found." when the header is absent,
+    so its presence is checked with Contains before reading it. Some endpoints do not return
+    this header, and reading it unconditionally masked the real response with a header exception.
+    #>
+    param (
+        [Parameter(Mandatory)]
+        $Result
+    )
+
+    if ($Result.Headers.Contains("x-ms-correlation-id")) {
+        return $Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1
+    }
+
+    return ""
+}
+
 function Send-Request {
     <#
     .SYNOPSIS
@@ -286,7 +309,7 @@ function Send-Request {
 
     $client = Get-HttpClient
     $result = Get-AsyncResult -Task $client.SendAsync($Request)
-    $correlationId = $result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1
+    $correlationId = Get-CorrelationId -Result $result
 
     if (-not $result.IsSuccessStatusCode) {
         $contentString = Get-AsyncResult -Task $result.Content.ReadAsStringAsync()
@@ -372,7 +395,7 @@ function Test-Result {
         $Result
     )
 
-    $correlationId = $Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1
+    $correlationId = Get-CorrelationId -Result $Result
     if (-not($Result.IsSuccessStatusCode))
     {
         $contentString = Get-AsyncResult -Task $Result.Content.ReadAsStringAsync()
@@ -400,17 +423,18 @@ function Assert-Result {
 
     if (-not($Result.IsSuccessStatusCode))
     {
+        $correlationId = Get-CorrelationId -Result $Result
         $contentString = Get-AsyncResult -Task $Result.Content.ReadAsStringAsync()
         if ($contentString)
         {
             $errorMessage = $contentString.Trim('.')
-            Write-Verbose "$(Get-LogDate): API Call returned $($Result.StatusCode): $($errorMessage). Correlation ID: $($($Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1))"
-            throw "$(Get-LogDate): API Call returned $($Result.StatusCode): $($errorMessage). Correlation ID: $($($Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1))"
+            Write-Verbose "$(Get-LogDate): API Call returned $($Result.StatusCode): $($errorMessage). Correlation ID: $correlationId"
+            throw "$(Get-LogDate): API Call returned $($Result.StatusCode): $($errorMessage). Correlation ID: $correlationId"
         }
         else
         {
-            Write-Verbose "$(Get-LogDate): API Call returned $($Result.StatusCode): $($Result.ReasonPhrase). Correlation ID: $($($Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1))"
-            throw "$(Get-LogDate): API Call returned $($Result.StatusCode): $($Result.ReasonPhrase). Correlation ID: $($($Result.Headers.GetValues("x-ms-correlation-id") | Select-Object -First 1))"
+            Write-Verbose "$(Get-LogDate): API Call returned $($Result.StatusCode): $($Result.ReasonPhrase). Correlation ID: $correlationId"
+            throw "$(Get-LogDate): API Call returned $($Result.StatusCode): $($Result.ReasonPhrase). Correlation ID: $correlationId"
         }
     }
 }

--- a/Source/Tests/FakeAzModule/RestHelpersClassMocks.psm1
+++ b/Source/Tests/FakeAzModule/RestHelpersClassMocks.psm1
@@ -11,6 +11,12 @@ class HttpClientResultHeaderMock
     }
     [string]GetValues($Header)
     {
+        # Mirror System.Net.Http.Headers.HttpHeaders.GetValues, which throws when the
+        # header is absent. Callers must guard with Contains() first.
+        if (-not $this.Headers.ContainsKey($Header))
+        {
+            throw [System.InvalidOperationException]::new("The given header was not found.")
+        }
         return $this.Headers[$Header]
     }
 }

--- a/Source/Tests/RESTHelpers.Tests.ps1
+++ b/Source/Tests/RESTHelpers.Tests.ps1
@@ -85,6 +85,39 @@ Describe 'RESTHelpers Tests' {
             }
         }
 
+        Context 'Testing Get-CorrelationId' {
+            It 'Returns the header value when the correlation ID header is present' {
+                $mockResult = [HttpClientResultMock]::new("ok", "text/plain", @{"x-ms-correlation-id" = "abc-123"})
+
+                $correlationId = Get-CorrelationId -Result $mockResult
+
+                $correlationId | Should -Be "abc-123"
+            }
+
+            It 'Returns an empty string when the correlation ID header is absent' {
+                # Regression: HttpHeaders.GetValues throws "The given header was not found."
+                # when the header is missing. Some endpoints omit x-ms-correlation-id, so
+                # reading it must not throw.
+                $mockResult = [HttpClientResultMock]::new("ok")
+
+                $correlationId = Get-CorrelationId -Result $mockResult
+
+                $correlationId | Should -Be ""
+            }
+        }
+
+        Context 'Testing Test-Result' {
+            It 'Returns true for a success response missing the correlation ID header' {
+                # Exact reproduction of the reported failure: Test-Result read
+                # x-ms-correlation-id unconditionally and threw "The given header was
+                # not found." for endpoints that omit it, causing bogus retries.
+                $mockResult = [HttpClientResultMock]::new("ok")
+
+                { Test-Result -Result $mockResult } | Should -Not -Throw
+                Test-Result -Result $mockResult | Should -BeTrue
+            }
+        }
+
         Context 'Testing Send-Request' {
             It 'Returns the response on a success status' {
                 $mockClient = [HttpClientMock]::new()
@@ -95,6 +128,17 @@ Describe 'RESTHelpers Tests' {
                 $result = Send-Request -Request "req"
 
                 $result | Should -Be $mockResult
+            }
+
+            It 'Succeeds when the response is missing the correlation ID header' {
+                # Regression for the "The given header was not found." failure: a successful
+                # response without x-ms-correlation-id must not throw.
+                $mockClient = [HttpClientMock]::new()
+                $mockResult = [HttpClientResultMock]::new("ok")
+                Mock Get-HttpClient { return $mockClient } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+                Mock Get-AsyncResult { return $mockResult } -ParameterFilter { $task -eq "SendAsyncResult" } -ModuleName "Microsoft.PowerPlatform.EnterprisePolicies"
+
+                { Send-Request -Request "req" } | Should -Not -Throw
             }
 
             It 'Throws with status code and correlation ID on a failure status' {


### PR DESCRIPTION
## Why

Running `Test-AppInsightsConnection` failed with `Request failed after 3 attempts. Last error: Exception calling "GetValues" with "1" argument(s): "The given header was not found."`, even though the underlying HTTP call was fine. The failure was misleading: it looked like a network/service problem but was actually a bug in the module's response handling.

## Root cause

.NET's `HttpHeaders.GetValues(name)` throws `InvalidOperationException: "The given header was not found."` when the header is absent (unlike `TryGetValues`). `Test-Result`, `Send-Request`, and `Assert-Result` in `RESTHelpers.ps1` read the `x-ms-correlation-id` response header unconditionally. The `TestAppInsightsConnection` endpoint does not return that header, so `Test-Result` threw on its very first line. The retry loop caught the exception, retried 3 times on the same header error, and finally surfaced the generic "Request failed after 3 attempts" message.

The test suite never caught this because the fake header mock returned `$null` for a missing key instead of throwing like the real type.

## What changed

- **`RESTHelpers.ps1`**: added a small `Get-CorrelationId` helper that guards with `Contains(...)` and returns an empty string when the header is absent, then routed all six correlation-id reads (`Send-Request`, `Test-Result`, `Assert-Result`) through it.
- **`RestHelpersClassMocks.psm1`**: made the test header mock's `GetValues` throw the same `InvalidOperationException` as real .NET when a header is missing, so this class of bug surfaces in tests going forward.
- **`RESTHelpers.Tests.ps1`**: added focused regression tests for `Get-CorrelationId`, `Test-Result`, and `Send-Request` covering the header-absent path.

The existing `Retry-After` read was already correctly guarded with `Contains(...)` and is unchanged. The `operation-location` reads in the Enable/Disable cmdlets genuinely require that header for their async flow and were intentionally left as-is.

## Verification

- 577 passed / 0 failed in both PowerShell Core (`pwsh`) and Windows PowerShell (`powershell`), `Build Succeeded!` in each.
- Change is limited to a private helper, so no public cmdlet docs were affected.